### PR TITLE
Fic broken Cert generation caused by DST Root CA X3 Expiration, and use a source of Certbot thats not ancient and maintained by the EFF them selves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-
+DEC 10 2021: Changed Certbot to V1.12 to alllow generating of a cert thats not broken by the recent DST Root CA X3 Expiration

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This is a simple script which requires 2 arguments
 
 ### For Pihole 5
 ```
-sudo wget https://raw.githubusercontent.com/varunsridharan/pi-hole-android-private-dns/main/pi-hole5.sh
+sudo wget https://github.com/GhostlyCrowd/pi-hole-android-private-dns/blob/main/pi-hole5.sh
 sudo bash pi-hole5.sh {domain_name} {email_for_letsencrypt}
 ```
 
@@ -32,7 +32,7 @@ sudo bash pi-hole5.sh {domain_name} {email_for_letsencrypt}
 
 ### For Pihole 4 & Below
 ```
-sudo wget https://raw.githubusercontent.com/varunsridharan/pi-hole-android-private-dns/main/pi-hole-android-private-dns.sh
+sudo wget https://github.com/GhostlyCrowd/pi-hole-android-private-dns/blob/main/pi-hole-android-private-dns.sh
 sudo bash pi-hole-android-private-dns.sh {domain_name} {email_for_letsencrypt}
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This is a simple script which requires 2 arguments
 
 ### For Pihole 5
 ```
-sudo wget https://raw.githubusercontent.com/GhostlyCrowd/pi-hole-android-private-dns/main/pi-hole-android-private-dns.sh
+sudo wget https://raw.githubusercontent.com/GhostlyCrowd/pi-hole-android-private-dns/main/pi-hole5.sh
 sudo bash pi-hole5.sh {domain_name} {email_for_letsencrypt}
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-[Checkout CHANGELOG.md](https://github.com/varunsridharan/pi-hole-android-private-dns/blob/main/CHANGELOG.md)
+[Checkout CHANGELOG.md](https://github.com/GhostlyCrowd/pi-hole-android-private-dns/blob/main/CHANGELOG.md)
 
 
 ## 🤝 Contributing

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This is a simple script which requires 2 arguments
 
 ### For Pihole 5
 ```
-sudo wget https://github.com/GhostlyCrowd/pi-hole-android-private-dns/blob/main/pi-hole5.sh
+sudo wget https://raw.githubusercontent.com/GhostlyCrowd/pi-hole-android-private-dns/main/pi-hole-android-private-dns.sh
 sudo bash pi-hole5.sh {domain_name} {email_for_letsencrypt}
 ```
 
@@ -32,7 +32,7 @@ sudo bash pi-hole5.sh {domain_name} {email_for_letsencrypt}
 
 ### For Pihole 4 & Below
 ```
-sudo wget https://github.com/GhostlyCrowd/pi-hole-android-private-dns/blob/main/pi-hole-android-private-dns.sh
+sudo wget https://raw.githubusercontent.com/GhostlyCrowd/pi-hole-android-private-dns/main/pi-hole-android-private-dns.sh
 sudo bash pi-hole-android-private-dns.sh {domain_name} {email_for_letsencrypt}
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ As a member of the open source community, I would like to give back, and am post
 ## Requirements
 1. Ubuntu / Debain Based (Any Version)
 2. Pi-Hole Installed With Web Server
-3. Allow The Following Ports in TCP (`80,443,853`)
+3. Forward The Following Ports in TCP (`80,443,853`) to your Pihole instance.
 
 ***Note*** I dont use Raspberry Pi to run Pi-Hole so i was not able to test. but the same steps are required for it.
 
 ## Installation
 This is a simple script which requires 2 arguments
-1. Domain Name To Run Android Private DNS Service
+1. Domain Name To Run Android Private DNS Service Example: dns.myhomenetwork.net 
 2. Email To Share with letsencrypt to get an SSL For Android Private DNS
 
 ### For Pihole 5
@@ -36,7 +36,7 @@ sudo wget https://raw.githubusercontent.com/varunsridharan/pi-hole-android-priva
 sudo bash pi-hole-android-private-dns.sh {domain_name} {email_for_letsencrypt}
 ```
 
-**Example Run** `sudo bash pi-hole-android-private-dns.sh mydns.example.com myemail@gmail.com`
+**Example Run** `sudo bash pi-hole-android-private-dns.sh dns.myhomenetwork.net myemail@gmail.com`
 
 ---
 

--- a/pi-hole-android-private-dns.sh
+++ b/pi-hole-android-private-dns.sh
@@ -72,7 +72,7 @@ echo "=============================="
 echo "Installing Python3 setting up virtual env and installing Certbot-nginx To Get SSL From Let's Encrypt"
 echo "=============================="
 echo ""
-sudo apt install python3 python3-venv libaugeas0
+sudo apt-get -y install python3 python3-venv libaugeas0
 sudo python3 -m venv /opt/certbot/
 sudo /opt/certbot/bin/pip install --upgrade pip
 sudo /opt/certbot/bin/pip install certbot certbot-nginx

--- a/pi-hole-android-private-dns.sh
+++ b/pi-hole-android-private-dns.sh
@@ -69,11 +69,14 @@ sudo nginx -t
 sudo systemctl reload nginx
 echo ""
 echo "=============================="
-echo "Installing Certbot To Get Valid Certificate From Let's Encrypt"
+echo "Installing Python3 setting up virtual env and installing Certbot-nginx To Get SSL From Let's Encrypt"
 echo "=============================="
 echo ""
-sudo add-apt-repository -y ppa:certbot/certbot
-sudo apt-get install -y certbot python-certbot-nginx
+sudo apt install python3 python3-venv libaugeas0
+sudo python3 -m venv /opt/certbot/
+sudo /opt/certbot/bin/pip install --upgrade pip
+sudo /opt/certbot/bin/pip install certbot certbot-nginx
+sudo ln -s /opt/certbot/bin/certbot /usr/bin/certbot
 echo ""
 echo "=============================="
 echo "Below Details are used to request for an SSL"
@@ -81,7 +84,7 @@ echo "Email : $SSL_CERT_EMAIL"
 echo "Domain : $DNS_DOMAIN_NAME"
 echo "=============================="
 echo ""
-sudo certbot --nginx -m "$SSL_CERT_EMAIL" -d "$DNS_DOMAIN_NAME" -n --agree-tos --no-eff-email
+sudo certbot --nginx -m "$SSL_CERT_EMAIL" -d "$DNS_DOMAIN_NAME" -n --agree-tos --no-eff-email --preferred-chain="ISRG Root X1" --nginx
 
 #
 # Starting All Required Services

--- a/pi-hole5.sh
+++ b/pi-hole5.sh
@@ -30,7 +30,7 @@ echo "=============================="
 echo "Installing Python3 setting up virtual env and installing Certbot-nginx To Get SSL From Let's Encrypt"
 echo "=============================="
 echo ""
-sudo apt install python3 python3-venv libaugeas0
+sudo apt-get -y install python3 python3-venv libaugeas0
 sudo python3 -m venv /opt/certbot/
 sudo /opt/certbot/bin/pip install --upgrade pip
 sudo /opt/certbot/bin/pip install certbot certbot-nginx

--- a/pi-hole5.sh
+++ b/pi-hole5.sh
@@ -42,7 +42,7 @@ echo "Email : $SSL_CERT_EMAIL"
 echo "Domain : $DNS_DOMAIN_NAME"
 echo "=============================="
 echo ""
-sudo certbot  certonly --webroot -w "${WEB_ROOT}" --preferred-challenges http -m "$SSL_CERT_EMAIL" -d "$DNS_DOMAIN_NAME" -n --agree-tos --no-eff-email --preferred-chain="ISRG Root X1" --nginx
+sudo certbot  certonly --webroot -w "${WEB_ROOT}" --preferred-challenges http -m "$SSL_CERT_EMAIL" -d "$DNS_DOMAIN_NAME" -n --agree-tos --no-eff-email --preferred-chain="ISRG Root X1"
 
 #
 # Starting All Required Services

--- a/pi-hole5.sh
+++ b/pi-hole5.sh
@@ -27,11 +27,14 @@ sudo apt-get -y install nginx
 
 echo ""
 echo "=============================="
-echo "Installing Certbot To Get SSL From Let's Encrypt"
+echo "Installing Python3 setting up virtual env and installing Certbot-nginx To Get SSL From Let's Encrypt"
 echo "=============================="
 echo ""
-sudo add-apt-repository -y ppa:certbot/certbot
-sudo apt-get install -y certbot python3-certbot-nginx
+sudo apt install python3 python3-venv libaugeas0
+sudo python3 -m venv /opt/certbot/
+sudo /opt/certbot/bin/pip install --upgrade pip
+sudo /opt/certbot/bin/pip install certbot certbot-nginx
+sudo ln -s /opt/certbot/bin/certbot /usr/bin/certbot
 echo ""
 echo "=============================="
 echo "Below Details are used to request for an SSL"
@@ -39,7 +42,7 @@ echo "Email : $SSL_CERT_EMAIL"
 echo "Domain : $DNS_DOMAIN_NAME"
 echo "=============================="
 echo ""
-sudo certbot  certonly --webroot -w "${WEB_ROOT}" --preferred-challenges http -m "$SSL_CERT_EMAIL" -d "$DNS_DOMAIN_NAME" -n --agree-tos --no-eff-email
+sudo certbot  certonly --webroot -w "${WEB_ROOT}" --preferred-challenges http -m "$SSL_CERT_EMAIL" -d "$DNS_DOMAIN_NAME" -n --agree-tos --no-eff-email --preferred-chain="ISRG Root X1" --nginx
 
 #
 # Starting All Required Services


### PR DESCRIPTION
As the title states. This fixes https://github.com/varunsridharan/pi-hole-android-private-dns/issues/9 

And gets Certbot to something that is not antiquated.  This should allow for this script to run error free 