### PR TITLE
Add ipv6 support

### DIFF
--- a/pi-hole-android-private-dns.sh
+++ b/pi-hole-android-private-dns.sh
@@ -101,8 +101,10 @@ sudo mkdir /etc/nginx/streams/
 sudo touch /etc/nginx/streams/dns-over-tls
 sudo echo "upstream dns-servers {
            server    127.0.0.1:53;
+	   server    [::1]:53;
     }
     server {
+      listen [::1]:853 ssl;
       listen 853 ssl; # managed by Certbot
       ssl_certificate /etc/letsencrypt/live/{dns_domain_name}/fullchain.pem; # managed by Certbot
       ssl_certificate_key /etc/letsencrypt/live/{dns_domain_name}/privkey.pem; # managed by Certbot

--- a/pi-hole-android-private-dns.sh
+++ b/pi-hole-android-private-dns.sh
@@ -104,7 +104,7 @@ sudo echo "upstream dns-servers {
 	   server    [::1]:53;
     }
     server {
-      listen [::1]:853 ssl;
+      listen [::]:853 ssl;
       listen 853 ssl; # managed by Certbot
       ssl_certificate /etc/letsencrypt/live/{dns_domain_name}/fullchain.pem; # managed by Certbot
       ssl_certificate_key /etc/letsencrypt/live/{dns_domain_name}/privkey.pem; # managed by Certbot

--- a/pi-hole5.sh
+++ b/pi-hole5.sh
@@ -70,8 +70,10 @@ sudo touch /etc/nginx/streams/dns-over-tls
 #      ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 sudo echo "upstream dns-servers {
            server    127.0.0.1:53;
+	   server    [::1]:53;
     }
     server {
+      listen [::1]:853 ssl;
       listen 853 ssl; # managed by Certbot
       ssl_certificate /etc/letsencrypt/live/{dns_domain_name}/fullchain.pem; # managed by Certbot
       ssl_certificate_key /etc/letsencrypt/live/{dns_domain_name}/privkey.pem; # managed by Certbot

--- a/pi-hole5.sh
+++ b/pi-hole5.sh
@@ -73,7 +73,7 @@ sudo echo "upstream dns-servers {
 	   server    [::1]:53;
     }
     server {
-      listen [::1]:853 ssl;
+      listen [::]:853 ssl;
       listen 853 ssl; # managed by Certbot
       ssl_certificate /etc/letsencrypt/live/{dns_domain_name}/fullchain.pem; # managed by Certbot
       ssl_certificate_key /etc/letsencrypt/live/{dns_domain_name}/privkey.pem; # managed by Certbot


### PR DESCRIPTION
I managed to little modify install script for pihole5 to add support for ipv6 in nginx stream configuration. But i'm not sure if it will throw error when starting nginx if server hasn't ipv6 connection available or if is ipv6 disabled in system. Maybe needs more investigation or check for ipv6 connectivity in script. I can't do that right now because i write this from mobile.